### PR TITLE
feat: added navigation to the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ Prefix your items with `(Template)` if the change is about the template and not 
 - Fixed Android missing Internet permission.
 - Fixed Android release on Google Play.
 - Fixed PowerShell script that was copying source control.
+- Added Navigation to the app.

--- a/doc/Architecture.md
+++ b/doc/Architecture.md
@@ -84,6 +84,10 @@ Business services are always declared using an interface and implemented in a se
 
 ## Presentation
 
+### Navigation
+
+See [Navigation.md](Navigation.md) for more details.
+
 ### State Management
 
 This application uses [Riverpod](https://pub.dev/packages/riverpod) to implement the MVVM pattern. The `ViewModel` class is used as a base class for all ViewModels.

--- a/doc/Navigation.md
+++ b/doc/Navigation.md
@@ -1,0 +1,53 @@
+# Navigation
+
+This project uses the [go_router](https://pub.dev/packages/go_router) to handle navigation.
+
+## Handling sections with bottom navigation bar
+
+To handle pages that share a menu, we use a [StatefulShellRoute](https://pub.dev/documentation/go_router/latest/go_router/StatefulShellRoute-class.html).
+
+## Registering routes
+
+To register a new section, you must add a stateful branch.
+Each branch represents a section. 
+Each page you add below the primary route will have the shell and anything that comes with it (like the bottom navigation bar).
+When you add a route nested in another route, if you navigate to that page and then navigate back,
+it will navigate back to the parent page.
+
+```dart
+StatefulShellBranch(
+  routes: [
+    GoRoute(
+      path: '/parent',
+      builder: (context, state) => const ParentPage(),
+      routes: [
+        GoRoute(
+          path: 'child',
+          builder: (context, state) => const ChildPage(),
+        ),
+      ],
+    ),
+  ],
+),
+```
+If you want a page without the shell, you can declare the route outside of the `StatefulShellRoute`.
+
+## How to navigate
+
+To navigate, you can reference the `router`, which is a global variable in the project.
+To navigate to a different page, you can use `go` or `push`.
+
+Here are a few examples:
+
+```dart
+// This will go to the child page. If you press the back button on that page, you will be on the parent page.
+router.go('/parent/child');
+
+// This will push the unrelated page to the top of the current navigation stack.
+router.push('/unrelated-page');
+
+// This will replace the current navigation stack with the unrelated page.
+router.go('/unrelated-page');
+```
+
+To change the section, you can simply navigate to a route created under the section's StatefulShellBranch.

--- a/src/app/lib/app.dart
+++ b/src/app/lib/app.dart
@@ -1,15 +1,15 @@
-import 'package:app/shell.dart';
+import 'package:app/app_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class App extends StatelessWidget {
+final class App extends StatelessWidget {
   const App({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const ProviderScope(
-      child: MaterialApp(
-        home: Shell(),
+    return ProviderScope(
+      child: MaterialApp.router(
+        routerConfig: router,
       ),
     );
   }

--- a/src/app/lib/app_router.dart
+++ b/src/app/lib/app_router.dart
@@ -1,0 +1,115 @@
+import 'package:app/presentation/dad_jokes/dad_jokes_page.dart';
+import 'package:app/presentation/dad_jokes/favorite_dad_jokes.dart';
+import 'package:app/presentation/router_examples/setting_page.dart';
+import 'package:app/presentation/router_examples/sub_page_with_menu_page.dart';
+import 'package:app/presentation/router_examples/sub_page_without_menu_page.dart';
+import 'package:app/shell.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+final _rootNavigatorKey = GlobalKey<NavigatorState>();
+final _homeNavigatorKey = GlobalKey<NavigatorState>();
+
+const String dadJokesPagePath = '/';
+const String favoriteDadJokesPagePath = '/favorites';
+const String subPageWithoutMenuPath = '/sub-page-without-menu';
+const String subPageWithMenuPath = 'sub-page';
+const String settingPagePath = '/settings';
+const String subPageWithMenuCompletePath = '/settings/sub-page';
+
+final router = GoRouter(
+  observers: [GoRouterObserver()],
+  initialLocation: dadJokesPagePath,
+  navigatorKey: _rootNavigatorKey,
+  routes: [
+    // Shell routes are used to create pages with a shell.
+    // StatefulShellRoutes save the state of each branch, allowing you to navigate between them without losing state.
+    // An index stack is a stack of widgets that are indexed by an integer value,
+    // that allows you to switch between them, while keeping their state.
+    // IndexedStack is the recommended way by the flutter team to handle stateful shell routes.
+    StatefulShellRoute.indexedStack(
+      builder: (context, state, navigationShell) =>
+          Shell(navigationShell: navigationShell),
+      branches: [
+        StatefulShellBranch(
+          // We can provide a navigator key if we want to use it elsewhere.
+          // But it is not necessary. A default one will be generated if not provided.
+          navigatorKey: _homeNavigatorKey,
+          routes: [
+            GoRoute(
+              path: dadJokesPagePath,
+              builder: (context, state) => const DadJokesPage(),
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: favoriteDadJokesPagePath,
+              builder: (context, state) => const FavoriteDadJokesPage(),
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: settingPagePath,
+              builder: (context, state) => const SettingPage(),
+              routes: [
+                GoRoute(
+                  path: subPageWithMenuPath,
+                  builder: (context, state) => const SubPageWithMenuPage(),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    ),
+    GoRoute(
+      path: subPageWithoutMenuPath,
+      builder: (context, state) => const SubPageWithoutMenuPage(),
+    ),
+  ],
+);
+
+class GoRouterObserver extends NavigatorObserver {
+  final Logger _logger = Logger();
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (route.settings.name != null) {
+      _logger.i('Pushing ${route.settings.name}.');
+    }
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (route.settings.name != null) {
+      _logger.i('Popped ${route.settings.name}.');
+    }
+  }
+
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (route.settings.name != null) {
+      _logger.i('Removed ${route.settings.name}.');
+    }
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    if (newRoute?.settings.name != null) {
+      _logger.i(
+        'Replaced ${oldRoute?.settings.name} with ${newRoute?.settings.name}.',
+      );
+    }
+  }
+}
+
+// Temporary logger.
+class Logger {
+  void i(String message) {
+    print(message);
+  }
+}

--- a/src/app/lib/presentation/dad_jokes/dad_jokes_page.dart
+++ b/src/app/lib/presentation/dad_jokes/dad_jokes_page.dart
@@ -21,23 +21,28 @@ final class DadJokesPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final dadJokesAsyncValue = ref.watch(_dadJokesProvider);
-    return dadJokesAsyncValue.when(
-      data: (dadJokes) {
-        return ListView.builder(
-          itemCount: dadJokes.length,
-          itemBuilder: (context, index) {
-            final dadJoke = dadJokes[index];
-            return DadJokeListItem(
-              key: Key(dadJoke.id),
-              dadJoke: dadJoke,
-            );
-          },
-        );
-      },
-      loading: () => const Center(
-        child: CircularProgressIndicator(),
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Dad Jokes'),
       ),
-      error: (error, stackTrace) => Text('Error: $error'),
+      body: dadJokesAsyncValue.when(
+        data: (dadJokes) {
+          return ListView.builder(
+            itemCount: dadJokes.length,
+            itemBuilder: (context, index) {
+              final dadJoke = dadJokes[index];
+              return DadJokeListItem(
+                key: Key(dadJoke.id),
+                dadJoke: dadJoke,
+              );
+            },
+          );
+        },
+        loading: () => const Center(
+          child: CircularProgressIndicator(),
+        ),
+        error: (error, stackTrace) => Text('Error: $error'),
+      ),
     );
   }
 }

--- a/src/app/lib/presentation/dad_jokes/favorite_dad_jokes.dart
+++ b/src/app/lib/presentation/dad_jokes/favorite_dad_jokes.dart
@@ -21,23 +21,28 @@ final class FavoriteDadJokesPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final dadJokesAsyncValue = ref.watch(_dadJokesProvider);
-    return dadJokesAsyncValue.when(
-      data: (dadJokes) {
-        return ListView.builder(
-          itemCount: dadJokes.length,
-          itemBuilder: (context, index) {
-            final dadJoke = dadJokes[index];
-            return DadJokeListItem(
-              key: Key(dadJoke.id),
-              dadJoke: dadJoke,
-            );
-          },
-        );
-      },
-      loading: () => const Center(
-        child: CircularProgressIndicator(),
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Dad Jokes'),
       ),
-      error: (error, stackTrace) => Text('Error: $error'),
+      body: dadJokesAsyncValue.when(
+        data: (dadJokes) {
+          return ListView.builder(
+            itemCount: dadJokes.length,
+            itemBuilder: (context, index) {
+              final dadJoke = dadJokes[index];
+              return DadJokeListItem(
+                key: Key(dadJoke.id),
+                dadJoke: dadJoke,
+              );
+            },
+          );
+        },
+        loading: () => const Center(
+          child: CircularProgressIndicator(),
+        ),
+        error: (error, stackTrace) => Text('Error: $error'),
+      ),
     );
   }
 }

--- a/src/app/lib/presentation/router_examples/setting_page.dart
+++ b/src/app/lib/presentation/router_examples/setting_page.dart
@@ -1,0 +1,42 @@
+import 'package:app/app_router.dart';
+import 'package:flutter/material.dart';
+
+final class SettingPage extends StatelessWidget {
+  const SettingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Setting Page'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            ElevatedButton(
+              child: const Text('Go to SubPageWithMenu'),
+              onPressed: () {
+                router.go('$settingPagePath/$subPageWithMenuPath');
+              },
+            ),
+            ElevatedButton(
+              child: const Text('Go to SubPageWithoutMenu'),
+              onPressed: () {
+                router.push(subPageWithoutMenuPath);
+              },
+            ),
+            ElevatedButton(
+              child: const Text(
+                'Go to SubPageWithoutMenu without back navigation',
+              ),
+              onPressed: () {
+                router.go(subPageWithoutMenuPath);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/src/app/lib/presentation/router_examples/sub_page_with_menu_page.dart
+++ b/src/app/lib/presentation/router_examples/sub_page_with_menu_page.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+final class SubPageWithMenuPage extends StatelessWidget {
+  const SubPageWithMenuPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Sub Page'),
+      ),
+      body: const Center(
+        child: Text(
+          'This is a sub page with a menu',
+        ),
+      ),
+    );
+  }
+}

--- a/src/app/lib/presentation/router_examples/sub_page_without_menu_page.dart
+++ b/src/app/lib/presentation/router_examples/sub_page_without_menu_page.dart
@@ -1,0 +1,45 @@
+import 'package:app/app_router.dart';
+import 'package:flutter/material.dart';
+
+final class SubPageWithoutMenuPage extends StatelessWidget {
+  const SubPageWithoutMenuPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Sub Page'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text(
+              'This is a sub page without a menu',
+            ),
+            ElevatedButton(
+              child: const Text('Return to the setting page'),
+              onPressed: () {
+                router.go(settingPagePath);
+              },
+            ),
+            ElevatedButton(
+              child: const Text('Go to SubPageWithMenu'),
+              onPressed: () {
+                router.go('$settingPagePath/$subPageWithMenuPath');
+              },
+            ),
+            ElevatedButton(
+              child: const Text(
+                'Go to to the dad jokes page',
+              ),
+              onPressed: () {
+                router.go(dadJokesPagePath);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/src/app/lib/shell.dart
+++ b/src/app/lib/shell.dart
@@ -1,31 +1,16 @@
-import 'package:app/presentation/dad_jokes/dad_jokes_page.dart';
-import 'package:app/presentation/dad_jokes/favorite_dad_jokes.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 /// The shell of the application.
-class Shell extends StatefulWidget {
-  const Shell({super.key});
+final class Shell extends StatelessWidget {
+  const Shell({super.key, required this.navigationShell});
 
-  @override
-  State<Shell> createState() => _ShellState();
-}
-
-/// The state of the [Shell].
-class _ShellState extends State<Shell> {
-  int _selectedIndex = 0;
-
-  static final List<Widget> _pages = <Widget>[
-    const DadJokesPage(),
-    const FavoriteDadJokesPage(),
-  ];
+  final StatefulNavigationShell navigationShell;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Dad Jokes'),
-      ),
-      body: _pages[_selectedIndex],
+      body: navigationShell,
       bottomNavigationBar: BottomNavigationBar(
         items: const <BottomNavigationBarItem>[
           BottomNavigationBarItem(
@@ -36,17 +21,14 @@ class _ShellState extends State<Shell> {
             icon: Icon(Icons.favorite),
             label: 'Favorites',
           ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.settings),
+            label: 'Settings',
+          ),
         ],
-        currentIndex: _selectedIndex,
-        onTap: _onTap,
+        currentIndex: navigationShell.currentIndex,
+        onTap: navigationShell.goBranch,
       ),
     );
-  }
-
-  /// Handles the tap event.
-  void _onTap(int index) {
-    setState(() {
-      _selectedIndex = index;
-    });
   }
 }

--- a/src/app/pubspec.lock
+++ b/src/app/pubspec.lock
@@ -280,6 +280,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: "28ef8a8320ab3bf5752424e6bca6961ce25108afc344f3127b5155caf7a792c8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.0.0"
   graphs:
     dependency: transitive
     description:

--- a/src/app/pubspec.yaml
+++ b/src/app/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     sdk: flutter
   flutter_riverpod: ^2.5.1
   get_it: ^7.6.7
+  go_router: ^14.0.0
   json_annotation: ^4.8.1
   retrofit: ^4.1.0
   rxdart: ^0.27.7


### PR DESCRIPTION
GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [x] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description

<!-- (Please describe the changes that this PR introduces.) -->
Added the go_router and navigation to the app

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major**
  - The template structure was changed.
- [x] **Minor**
  - New functionalities were added.
- [ ] **Patch**
  - A bug in behavior was fixed.
  - Documentation was changed.

## PR Checklist 

### Always applicable
No matter your changes, these checks always apply.
- [x] Your conventional commits are aligned with the **Impact on version** section.
- [x] Updated [CHANGELOG.md](../CHANGELOG.md).
  - Use the latest Major.Minor.X header if you do a **Patch** change.
  - Create a new Major.Minor.X header if you do a **Minor** or **Major** change.
  - If you create a new header, it aligns with the **Impact on version** section and matches what is generated in the build pipeline.
- [x] Documentation files were updated according with the changes.
- [x] Images about the template are referenced from the [wiki](https://github.com/nventive/UnoApplicationTemplate/wiki/Images) and added as images in this git.
- [x] TODO comments are hints for next steps for users of the template and not planned work.

### Contextual
Based on your changes these checks may not apply.
- [x] Automated tests for the changes have been added/updated.
- [x] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->