### PR TITLE
fix: ensure remote config fetch interval name is consitent for all env

### DIFF
--- a/src/app/.env.dev
+++ b/src/app/.env.dev
@@ -4,4 +4,4 @@ MINIMUM_LEVEL='debug'
 DAD_JOKES_BASE_URL='https://www.reddit.com/r/dadjokes'
 APP_STORE_URL_IOS=https://apps.apple.com/us/app/uno-calculator/id1464736591
 APP_STORE_URL_Android=https://play.google.com/store/apps/details?id=uno.platform.calculator
-REMOTE_CONFIG_FETCH_INTERVAL=1
+REMOTE_CONFIG_FETCH_INTERVAL_MINUTES=1

--- a/src/app/.env.prod
+++ b/src/app/.env.prod
@@ -4,4 +4,4 @@ MINIMUM_LEVEL='warning'
 DAD_JOKES_BASE_URL='https://www.reddit.com/r/dadjokes'
 APP_STORE_URL_IOS=https://apps.apple.com/us/app/uno-calculator/id1464736591
 APP_STORE_URL_Android=https://play.google.com/store/apps/details?id=uno.platform.calculator
-REMOTE_CONFIG_FETCH_INTERVAL=720
+REMOTE_CONFIG_FETCH_INTERVAL_MINUTES=720

--- a/src/app/lib/main.dart
+++ b/src/app/lib/main.dart
@@ -65,7 +65,8 @@ Future _initializeFirebaseServices() async {
       RemoteConfigSettings(
         fetchTimeout: const Duration(minutes: 1),
         minimumFetchInterval: Duration(
-          minutes: int.parse(dotenv.env["REMOTE_CONFIG_FETCH_INTERVAL"]!),
+          minutes:
+              int.parse(dotenv.env["REMOTE_CONFIG_FETCH_INTERVAL_MINUTES"]!),
         ),
       ),
     );


### PR DESCRIPTION
…vironments

GitHub Issue: #

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [x] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:

## Description

Ensure the remote config fetch interval config name is consistent for all environments.

## Impact on version
<!-- Please select one or more based on your commits. -->

- [ ] **Major**
  - The template structure was changed.
- [ ] **Minor**
  - New functionalities were added.
- [x] **Patch**
  - A bug in behavior was fixed.
  - Documentation was changed.

## PR Checklist 

### Always applicable
No matter your changes, these checks always apply.
- [x] Your conventional commits are aligned with the **Impact on version** section.
- [x] Updated [CHANGELOG.md](../CHANGELOG.md).
  - Use the latest Major.Minor.X header if you do a **Patch** change.
  - Create a new Major.Minor.X header if you do a **Minor** or **Major** change.
  - If you create a new header, it aligns with the **Impact on version** section and matches what is generated in the build pipeline.
- [x] Documentation files were updated according with the changes.
- [x] Images about the template are referenced from the [wiki](https://github.com/nventive/UnoApplicationTemplate/wiki/Images) and added as images in this git.
- [x] TODO comments are hints for next steps for users of the template and not planned work.

### Contextual
Based on your changes these checks may not apply.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Tested on all relevant platforms

## Other information

<!-- Please provide any additional information if necessary -->

## Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->